### PR TITLE
Solved by re-inserting filter

### DIFF
--- a/mod_poc.c
+++ b/mod_poc.c
@@ -31,6 +31,10 @@ static apr_status_t input_filter(ap_filter_t *f, apr_bucket_brigade *bb, ap_inpu
 static int handler(request_rec* r) {
 	// skip processing subrequests
 	if ((r->main != NULL) || (r->prev != NULL)) {
+                if (!strcmp(r->handler, CGI_MAGIC_TYPE) || !strcmp(r->handler, "cgi-script")) {
+                        if (r->prev != NULL && r->prev->input_filters != NULL && r->prev->input_filters->frec != NULL && r->prev->input_filters->frec->name != NULL && !strcmp(r->prev->input_filters->frec->name, "poc_in"))
+                                ap_add_input_filter("poc_IN", r->prev->input_filters->ctx, r, r->connection);
+                }
 		return DECLINED;
 	}
 


### PR DESCRIPTION
With the CGI version, the request goes through the `mod_actions` handler which creates a subrequest which `mod_cgid` finally acts upon. However, the input filter chain for the subrequest lacks the input filter from `mod_poc`, and therefore also its cached brigade. Thus we can add a check to handle this specific subrequest situation, where the request is meant for `mod_cgid` and the first input filter for the _main_ (`prev`) request is `poc_in`, i.e. when `mod_poc` has processed the main request. In that case, the input filter context is simply carried over. (There are several null checks, because I wasn't sure which members are guaranteed to exist. It is possible that some are unnecessary.)